### PR TITLE
Fix 'missing port' case when initialize a NewLock of consul

### DIFF
--- a/lock/consul/consul.go
+++ b/lock/consul/consul.go
@@ -88,7 +88,7 @@ func NewLock(opts ...lock.Option) lock.Lock {
 		addr, port, err := net.SplitHostPort(options.Nodes[0])
 		if ae, ok := err.(*net.AddrError); ok && ae.Err == "missing port in address" {
 			port = "8500"
-			config.Address = fmt.Sprintf("%s:%s", addr, port)
+			config.Address = fmt.Sprintf("%s:%s", ae.Addr, port)
 		} else if err == nil {
 			config.Address = fmt.Sprintf("%s:%s", addr, port)
 		}


### PR DESCRIPTION
Currently, we get an empty host from outputs of net.SplitHostPort(...) for 'missing port' case.
We should get orginal host of the Node without port from net.AddrError.